### PR TITLE
feat: remove algumas alocações e adiciona uso de `unwrap_or`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -9,15 +9,14 @@ const URLS: [&str; 2] = [
 
 fn main() {
     let contents = utils::download_data(&URLS);
-    let channels: Vec<Channel> = contents
-        .iter()
-        .map(|c| Channel::read_from(&c[..]).unwrap())
-        .collect();
+    let channels = contents.flat_map(|c| Channel::read_from(&c[..]));
 
-    for item in channels.iter().flat_map(|c| c.items.iter().rev()) {
-        let title = item.title().unwrap();
-        let link = item.link().unwrap();
-        let pub_date = item.pub_date().unwrap();
+    for item in channels.flat_map(|c| c.items.into_iter().rev()) {
+        let title = item.title().unwrap_or("Título não encontrado");
+        let link = item.link().unwrap_or("Link não encontrado");
+        let pub_date = item
+            .pub_date()
+            .unwrap_or("Data de publicação não encontrada");
 
         println!("{title}");
         println!("{link}");

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,11 +1,9 @@
 use bytes::Bytes;
+use reqwest::blocking::Response;
 
-pub fn download_data(urls: &[&str]) -> Vec<Bytes> {
-    let mut contents = Vec::with_capacity(urls.len());
-
-    for url in urls {
-        let content = reqwest::blocking::get(*url).unwrap();
-        contents.push(content.bytes().unwrap());
-    }
-    contents
+pub fn download_data<'a>(urls: &'a [&'a str]) -> impl Iterator<Item = Bytes> + 'a {
+    urls.iter()
+        .copied()
+        .flat_map(reqwest::blocking::get)
+        .flat_map(Response::bytes)
 }


### PR DESCRIPTION
Evita a alocação de dois `Vec`s, um em `download_data` e o outro na `main`, reduzindo (um pouquinho kkkk) a latência da aplicação.

Adiciona mensagens de fallback quando `title`, `link` ou `pub_date` não forem encontrados, ao invés de parar a execução do programa com um panic